### PR TITLE
Slow startup Tomcat startup times

### DIFF
--- a/example.1_7.docker-compose.yml
+++ b/example.1_7.docker-compose.yml
@@ -18,5 +18,6 @@ vivotomcat:
         - vivodb:db
     environment:
         - MYDOMAIN
+        - VIVO_EMAIL
         - CATALINA_OPTS=-Xmx2048m -XX:MaxPermSize=128m
     restart: always

--- a/example.1_8.docker-compose.yml
+++ b/example.1_8.docker-compose.yml
@@ -18,5 +18,6 @@ vivotomcat:
         - vivodb:db
     environment:
         - MYDOMAIN
+        - VIVO_EMAIL
         - CATALINA_OPTS=-Xmx2048m -XX:MaxPermSize=128m
     restart: always

--- a/tomcat/prop_util/prop_util.py
+++ b/tomcat/prop_util/prop_util.py
@@ -22,6 +22,11 @@ if __name__ == '__main__':
         new_value = value.replace("mydomain.edu", newdomain)
         print "Changing key %s from %s to %s" % (key, value, new_value)
         p[key] = new_value
+    #Only set email keys if env var present.
+    if os.environ.get('VIVO_EMAIL', False) != "true":
+        print "Removing email settings."
+        p['email.smtpHost'] = ""
+        p['email.replyTo'] = ""
     #Set DB values based on docker-provided environment variables
     p['VitroConnection.DataSource.url'] = "jdbc:mysql://db/%s" % os.getenv('DB_ENV_MYSQL_DATABASE')
     p['VitroConnection.DataSource.username'] = os.getenv('DB_ENV_MYSQL_USER')


### PR DESCRIPTION
This is more of a suggestion than a PR.  

In the README, the slow Tomcat startup times are mentioned a couple of time as well as the SMTP warning.  By setting the SMTP variables to blank in runtime.properties, this startup time can be reduced significantly.  In my testing about 50 seconds.  This is because if these values aren't set to a real server (is often the case in testing) the application [tries to connect](https://github.com/vivo-project/Vitro/blob/4da0e351822cd69de014ebad5731358fd7f076da/webapp/src/edu/cornell/mannlib/vitro/webapp/email/FreemarkerEmailFactory.java#L184) to the non-existent server and waits a period of time before timing out.    

These changes look for a VIVO_EMAIL environment variable set to "true" and will only set the `email.smtpHost` and `email.replyTo` in runtime.properties if found.  This means the "contact us" features of the application will be unavailable but since most users would be using the docker config for testing, this seems to be a good default.  

Other ideas?  
